### PR TITLE
Add patches to enable reading of the u-boot environment from EEPROM

### DIFF
--- a/recipes-bsp/u-boot/u-boot-xlnx/0008-Add-CONFIG_ENV_IS_IN_EEPROM.patch
+++ b/recipes-bsp/u-boot/u-boot-xlnx/0008-Add-CONFIG_ENV_IS_IN_EEPROM.patch
@@ -1,0 +1,89 @@
+diff -ruN ../git-orig/arch/arm/dts/zynq-red-pitaya.dts ./arch/arm/dts/zynq-red-pitaya.dts
+--- ../git-orig/arch/arm/dts/zynq-red-pitaya.dts	2020-02-13 04:57:33.180142288 +0000
++++ ./arch/arm/dts/zynq-red-pitaya.dts	2020-02-13 10:01:43.829774248 +0000
+@@ -62,3 +62,18 @@
+ 	dr_mode = "host";
+ 	usb-phy = <&usb_phy0>;
+ };
++
++&i2c0 {
++      status = "okay";
++      eeprom@50 {
++		compatible = "24c64";
++		reg = <0x50>;
++		pagesize = <32>;
++	};
++
++	eeprom@51 {
++		compatible = "24c64";
++		reg = <0x51>;
++		pagesize = <32>;
++	};
++};
+diff -ruN ../git-orig/configs/zynq_red_pitaya_defconfig ./configs/zynq_red_pitaya_defconfig
+--- ../git-orig/configs/zynq_red_pitaya_defconfig	2020-02-13 04:57:33.772122721 +0000
++++ ./configs/zynq_red_pitaya_defconfig	2020-02-13 08:55:07.583509891 +0000
+@@ -14,9 +14,9 @@
+ CONFIG_CMD_PING=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_CMD_EXT4=y
+-# CONFIG_ENV_IS_IN_EEPROM=y
+-# CONFIG_ENV_EEPROM_IS_ON_I2C=y
+-CONFIG_ENV_IS_NOWHERE=y
++CONFIG_ENV_IS_IN_EEPROM=y
++CONFIG_ENV_EEPROM_IS_ON_I2C=y
++# CONFIG_ENV_IS_NOWHERE=y
+ # CONFIG_DM_DEBUG=y
+ CONFIG_DM_MMC=y
+ CONFIG_ZYNQ_SDHCI=y
+diff -ruN ../git-orig/include/configs/zynq_red_pitaya.h ./include/configs/zynq_red_pitaya.h
+--- ../git-orig/include/configs/zynq_red_pitaya.h	2020-02-13 04:57:33.772122721 +0000
++++ ./include/configs/zynq_red_pitaya.h	2020-02-13 07:54:06.981203877 +0000
+@@ -1,9 +1,16 @@
+ #ifndef __CONFIG_ZYNQ_RED_PITAYA_H
+ #define __CONFIG_ZYNQ_RED_PITAYA_H
+ 
++#define CONFIG_ZYNQ_I2C0
++#define CONFIG_ZYNQ_EEPROM
++
+ /* originally based on zynq_zc70x.h with many additions. */
+ 
+-//#define CONFIG_CMD_EEPROM
++// this seems to be needed to enable reading of config from EEPROM
++#define CONFIG_CMD_EEPROM
++// Note: this CONFIG_ENV_IS_IN_EEPROM macro makes the config ignore CONFIG_EXTRA_ENV_SETTINGS
++// It also influences the behaviour of zynq-common.h, so best to define before
++#define CONFIG_ENV_IS_IN_EEPROM
+ 
+ #include <configs/zynq-common.h>
+ 
+@@ -29,11 +36,17 @@
+ #define CONFIG_SYS_EEPROM_PAGE_WRITE_BITS	5
+ #define CONFIG_SYS_EEPROM_SIZE			8192 /* Bytes */
+ 
++// CONFIG_SYS_I2C_MUX_EEPROM_SEL is mandatory with CONFIG_ENV_IS_IN_EEPROM
++#define CONFIG_SYS_I2C_MUX_EEPROM_SEL 0x4
++// CONFIG_SYS_I2C_MUX_ADDR is mandatory with CONFIG_ENV_IS_IN_EEPROM
++#define CONFIG_SYS_I2C_MUX_ADDR 0x74
++
+ #undef CONFIG_EXTRA_ENV_SETTINGS
+ 
+ #define CONFIG_ENV_SIZE		1024 /* Total Size of Environment Sector */
+ #define CONFIG_ENV_OFFSET	(2048*3) /* WP area starts at last 1/4 of 8k eeprom */
+ 
++/* Take those away for now
+ #define CONFIG_EXTRA_ENV_SETTINGS \
+     "bootcmd=run $modeboot\0" \
+     "bootdelay=3\0" \
+@@ -52,9 +65,10 @@
+     "fdt_high=0x20000000\0" \
+     "initrd_high=0x20000000\0" \
+     "sdboot=echo Running script from SD... && mmcinfo && fatload mmc 0 0x2000000 boot.scr && source 0x2000000\0" \
+-    "ethaddr=88:88:88:88:88:88\0" \
++    "ethaddr=00:88:55:88:88:88\0" \
+     "nav_code=0\0" \
+     "hw_rev=0\0" \
+     "serial=0\0"
++*/
+ 
+ #endif /* __CONFIG_ZYNQ_RED_PITAYA_H */

--- a/recipes-bsp/u-boot/u-boot-xlnx_2019.1.bb
+++ b/recipes-bsp/u-boot/u-boot-xlnx_2019.1.bb
@@ -12,7 +12,7 @@ DEPENDS += " bison-native"
 require recipes-bsp/u-boot/u-boot-xlnx.inc
 require recipes-bsp/u-boot/u-boot-spl-zynq-init.inc
 
-SRC_URI_append_redpitaya = " file://0001-Adding-red-pitaya-changes.2019.patch file://0002-Modify-config-for-2017.1.2019.patch file://0003-Updating-config-for-2017.2.2019.patch file://0004-Add-CONFIG_SYS_TEXT_BASE-a-NEW-required-option-in-20.2019.patch file://0005-Add-extra-environment-settings-patch.2019.patch file://0006-Remove-underscores-from-beginning-of-libfdt-header-d.2019.patch file://0007-Changes-for-xilinx-v2018.1-in-yocto.2019.patch file://0001-xilinx-v2019.1-required-changes-to-compile-and-run.patch file://0002-Refactor-zynq_red_pitaya_defconf-to-better-reflect-n.patch file://0001-Remove-u-boot-environment-storage-options-because-th.patch file://u-boot.script"
+SRC_URI_append_redpitaya = " file://0001-Adding-red-pitaya-changes.2019.patch file://0002-Modify-config-for-2017.1.2019.patch file://0003-Updating-config-for-2017.2.2019.patch file://0004-Add-CONFIG_SYS_TEXT_BASE-a-NEW-required-option-in-20.2019.patch file://0005-Add-extra-environment-settings-patch.2019.patch file://0006-Remove-underscores-from-beginning-of-libfdt-header-d.2019.patch file://0007-Changes-for-xilinx-v2018.1-in-yocto.2019.patch file://0001-xilinx-v2019.1-required-changes-to-compile-and-run.patch file://0002-Refactor-zynq_red_pitaya_defconf-to-better-reflect-n.patch file://0001-Remove-u-boot-environment-storage-options-because-th.patch file://u-boot.script file://0008-Add-CONFIG_ENV_IS_IN_EEPROM.patch"
 
 # define UBOOT_ENV file immediately
 UBOOT_ENV_SUFFIX := "scr"


### PR DESCRIPTION
Hey guys,

please see a patch to make the reading of the u-boot environment from EEPROM work. It required a few things to change.
As Danny suggested a made a patch on top of all the other applied patches, although it's a correction of some of the other patches/undoing them. Feels weird, but works.
